### PR TITLE
Set CUSTOM ami_type to al2023 userdata

### DIFF
--- a/modules/_user_data/main.tf
+++ b/modules/_user_data/main.tf
@@ -30,6 +30,7 @@ locals {
     WINDOWS_FULL_2022_x86_64   = "windows"
     AL2023_x86_64_STANDARD     = "al2023"
     AL2023_ARM_64_STANDARD     = "al2023"
+    CUSTOM                     = "al2023"
   }
   # Try to use `ami_type` first, but fall back to current, default behavior
   # TODO - will be removed in v21.0


### PR DESCRIPTION
## Description
We are utilizing Nodeadm for our Custom AMI and would like to use the NodeConfig like AL2023

## Motivation and Context
Just setting AMI_TYPE = AL2023_x86_64_STANDARD led to some weird networking issues, presumably because this is passed into the AWS API and it does something we don't want.

We are actually using a CUSTOM AMI, but it does not have a functional bootstrap.sh script as it uses Nodeadm instead.

## Breaking Changes
We currently don't set ami_type at all so it defaults to the linux platform. This shouldn't break any of our existing code.

## How Has This Been Tested?
Will use this module version in one of our internal clusters
