### PR TITLE
fix: Handle CUSTOM ami_type in self-managed node groups

### DIFF
--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -29,6 +29,7 @@ locals {
     AL2023_x86_64_NEURON       = "al2023"
     AL2023_x86_64_NVIDIA       = "al2023"
     AL2023_ARM_64_NVIDIA       = "al2023"
+    CUSTOM                     = "al2023"
   }
 
   user_data_type = local.ami_type_to_user_data_type[var.ami_type]
@@ -38,6 +39,7 @@ locals {
     AL2_x86_64                 = "/aws/service/eks/optimized-ami/${local.ssm_cluster_version}/amazon-linux-2/recommended/image_id"
     AL2_x86_64_GPU             = "/aws/service/eks/optimized-ami/${local.ssm_cluster_version}/amazon-linux-2-gpu/recommended/image_id"
     AL2_ARM_64                 = "/aws/service/eks/optimized-ami/${local.ssm_cluster_version}/amazon-linux-2-arm64/recommended/image_id"
+    CUSTOM                     = "NONE"
     BOTTLEROCKET_ARM_64        = "/aws/service/bottlerocket/aws-k8s-${local.ssm_cluster_version}/arm64/latest/image_id"
     BOTTLEROCKET_x86_64        = "/aws/service/bottlerocket/aws-k8s-${local.ssm_cluster_version}/x86_64/latest/image_id"
     BOTTLEROCKET_ARM_64_FIPS   = "/aws/service/bottlerocket/aws-k8s-${local.ssm_cluster_version}-fips/arm64/latest/image_id"


### PR DESCRIPTION
## Summary
Specifying `ami_type = CUSTOM` breaks self-managed node groups with errors like:
```
│ Error: Invalid index
│
│   on .terraform/modules/common_eks.eks/modules/self-managed-node-group/main.tf line 34, in locals:
│   34:   user_data_type = local.ami_type_to_user_data_type[var.ami_type]
│     ├────────────────
│     │ local.ami_type_to_user_data_type is object with 18 attributes
│     │ var.ami_type is "CUSTOM"
│
│ The given key does not identify an element in this collection value.
```

## Test Plan
When referencing this branch on a cluster specifying `ami_type = CUSTOM`. `terraform plan` now succeeds.